### PR TITLE
QueryService look up conceptId of cohort is now more robust and 

### DIFF
--- a/model/src/main/java/org/snomed/heathanalytics/model/pojo/TermHolder.java
+++ b/model/src/main/java/org/snomed/heathanalytics/model/pojo/TermHolder.java
@@ -4,11 +4,16 @@ public class TermHolder {
 
 	private String term;
 
+	public TermHolder() {
+	}
+
+	public TermHolder(String term) {
+		setTerm(term);
+	}
+
 	public String getTerm() {
 		return term;
 	}
 
-	public void setTerm(String term) {
-		this.term = term;
-	}
+	public void setTerm(String term) {this.term = term;}
 }


### PR DESCRIPTION
doesn't stop after first error; also entries/encounters which could not been looked up are deleted from result set 